### PR TITLE
update description and change discard-action type as identityref

### DIFF
--- a/yang/ietf-schedule.yang
+++ b/yang/ietf-schedule.yang
@@ -148,43 +148,43 @@ module ietf-schedule {
   identity secondly {
     base frequency-type;
     description
-      "Identity for a repeating event based on an interval of
+      "Indicates a repeating rule based on an interval of
        a second or more.";
   }
   identity minutely {
     base frequency-type;
     description
-      "Identity for a repeating event based on an interval of
+      "Indicates a repeating rule based on an interval of
        a minute or more.";
   }
   identity hourly {
     base frequency-type;
     description
-      "Identity for a repeating event based on an interval of
+      "Indicates a repeating rule based on an interval of
        an hour or more.";
   }
   identity daily {
     base frequency-type;
     description
-      "Identity for a repeating event based on an interval of
+      "Indicates a repeating rule based on an interval of
        a day or more.";
   }
   identity weekly {
     base frequency-type;
     description
-      "Identity for a repeating event based on an interval of
+      "Indicates a repeating rule based on an interval of
        a week or more.";
   }
   identity monthly {
     base frequency-type;
     description
-      "Identity for a repeating event based on an interval of
+      "Indicates a repeating rule based on an interval of
        a month or more.";
   }
   identity yearly {
     base frequency-type;
     description
-      "Identity for a repeating event based on an interval of
+      "Indicates a repeating rule based on an interval of
        a year or more.";
   }
   identity schedule-type {
@@ -194,13 +194,13 @@ module ietf-schedule {
   identity period {
     base schedule-type;
     description
-      "Identity for a period based schedule.";
+      "Indicates a period based schedule.";
   }
   
   identity recurrence {
     base schedule-type;
     description
-      "Identity for a recurrence based schedule.";
+      "Indicates a recurrence based schedule.";
   }
   identity schedule-state {
     description
@@ -209,22 +209,22 @@ module ietf-schedule {
   identity enabled {
     base schedule-state;
     description
-      "Identity for the recurrence with enabled state.";
+      "Indicates a recurrence with an enabled state.";
   }
   identity disabled {
     base schedule-state;
     description
-      "Identity for the recurrence with disabled state.";
+      "Indicates a recurrence with a disabled state.";
   }
   identity out-of-date {
     base schedule-state;
     description
-      "Identity for the recurrence with out-of-date state.";
+      "Indicates a recurrence with an out-of-date state.";
   }
   
   identity discard-action {
     description
-      "Identity for the discard options.";
+      "Indicates that schedule will be discarded.";
   }
   
   identity warning {

--- a/yang/ietf-schedule.yang
+++ b/yang/ietf-schedule.yang
@@ -30,8 +30,8 @@ module ietf-schedule {
      Author:   Daniel King
                <mailto:d.king@lancaster.ac.uk>";
   description
-    "This YANG module defines a set of common schedule groupings
-     which are applicable for scheduling purposes such as events,
+    "This YANG module defines a set of common groupings which
+     are applicable for scheduling purposes such as events,
      policy, services, or resources based on date and time.
 
      Copyright (c) 2024 IETF Trust and the persons identified
@@ -230,20 +230,20 @@ module ietf-schedule {
   identity warning {
     base discard-action;
     description
-      "Identity for the action that a warning message is generated
+      "Indicates that a warning message is generated
        when a schedule is discarded.";
   }
   identity error {
     base discard-action;
     description
-      "Identity for the action that an error message is generated
+      "Indicates that an error message is generated
        when a schedule is discarded.";
   }
   identity silently-discard {
     base discard-action;
     description
-      "Identity for the action that silently discards an invalid
-       schedule.";
+      "Indicates that an invalid schedule is silently 
+       discarded.";
   }
 
   grouping generic-schedule-params {
@@ -723,5 +723,3 @@ module ietf-schedule {
     }    
   }
 }
-
-

--- a/yang/ietf-schedule.yang
+++ b/yang/ietf-schedule.yang
@@ -30,12 +30,9 @@ module ietf-schedule {
      Author:   Daniel King
                <mailto:d.king@lancaster.ac.uk>";
   description
-    "This YANG module defines common shedule groupings. It defines
-     in particuler groupings for Internet Calendaring and Scheduling
-     Core Object Specification (iCalendar) data types: period of time
-     and recurrence rule, for representing and exchanging calendaring
-     and scheduling information. The YANG module complies with
-     Sections 3.3.9 and 3.3.10 of RFC 5545.
+    "This YANG module defines a set of common schedule groupings
+     which are applicable for scheduling purposes such as events,
+     policy, services, or resources based on date and time.
 
      Copyright (c) 2024 IETF Trust and the persons identified
      as authors of the code. All rights reserved.
@@ -210,17 +207,44 @@ module ietf-schedule {
       "Base identity for schedule state.";
   }
   identity enabled {
+    base schedule-state;
     description
       "Identity for the recurrence with enabled state.";
   }
   identity disabled {
+    base schedule-state;
     description
       "Identity for the recurrence with disabled state.";
   }
   identity out-of-date {
+    base schedule-state;
     description
       "Identity for the recurrence with out-of-date state.";
-  }  
+  }
+  
+  identity discard-action {
+    description
+      "Identity for the discard options.";
+  }
+  
+  identity warning {
+    base discard-action;
+    description
+      "Identity for the action that a warning message is generated
+       when a schedule is discarded.";
+  }
+  identity error {
+    base discard-action;
+    description
+      "Identity for the action that an error message is generated
+       when a schedule is discarded.";
+  }
+  identity silently-discard {
+    base discard-action;
+    description
+      "Identity for the action that silently discards an invalid
+       schedule.";
+  }
 
   grouping generic-schedule-params {
     description
@@ -272,22 +296,13 @@ module ietf-schedule {
          the last occurence exceed 'max-allowed-end'.";
     }
     leaf discard-action {
-      type enumeration {
-        enum warning {
-          description
-            "A warning message is generated when a schedule is
-             discarded when enforcing the guards in this grouping
-             or it is received out-of-date.";
-        }
-        enum silently-discard {
-          description
-           "Discards silently a schedule when it is invalid because
-            it is not consistent with the guards in this grouping or
-            it is received out-of-date.";
-        }
+      type identityref {
+        base discard-action;
       }
       description
-        "Specifies the behavior when a schedule is discarded.";    
+        "Specifies the behavior when a schedule is discarded when
+         enforcing the guards in this grouping or it is received
+         out-of-date.";    
     }
   }
 
@@ -708,4 +723,5 @@ module ietf-schedule {
     }    
   }
 }
+
 

--- a/yang/tree/sch-generic-params.txt
+++ b/yang/tree/sch-generic-params.txt
@@ -6,7 +6,7 @@ module: ietf-schedule
     +-- max-allowed-start?      yang:date-and-time
     +-- min-allowed-start?      yang:date-and-time
     +-- max-allowed-end?        yang:date-and-time
-    +-- discard-action?         enumeration
+    +-- discard-action?         identityref
   grouping period-of-time:
     ...
   grouping recurrence:


### PR DESCRIPTION
In the abstract, I was not sure how to parse "..scheduling information such as event, policy, services, or resources..", are these examples well known and established as scheduling information?
Med: Fixed/

The introduction made sense as a motivation for the document initially, but it should be rephrased esp that the referenced modules are expected to be updated to use this common module going forward. You may create an appendix with this historical context if needed.
Med: Fixed

Section 3.1, the description is a bit sparse; also there are no examples that use this grouping. Please expand.
Qiufang: Fixed in https://github.com/netmod-wg/schedule-yang/pull/9.

The description inside the YANG module is old and incorrect, it says 2 groupings and focused only on iCalendar.
Qiufang: Fixed.

s/RFC XXXX: A YANG Data Model for Scheduling/RFC XXXX: A Common YANG Data Model for Scheduling/
Med: Fixed

for discard-action, is there a possibility for creating new actions in future or these two are the only ones? I am asking to make sure that the choice of modeling this as enum is correct or not.
Qiufang: Fixed

In these lists "leaf-list date-times" and "leaf-list dates", is there any ordering constraint that should be added explicitly in text?
Qiufang: No leaf-list date-times and dates definition in the current module anymore; I don't think ordering affects the recurrence rules

Section 3.4 needs more descriptive text for period and timeticks. The yang module has a long must statement for verification that should be explained here in text.

Section 3.5 needs more descriptive text for by* leaves -> "An array of the "bysecond" (or "byminut", "byhour") specifies a list of seconds within a minute (or minutes within an hour, hours of the day)." The examples in the appendix gave some hints but the description should be clearer.

s/byminut/byminute/
Med: Fixed

Appendix A.1, the text says end date is Dec 31, 2027 but the JSON says 1st Dec - "2027-12-01T18:00:00Z"
Med: Fixed

Appendix A.2, the text says Dec 1, 2025 but the example says 1st Nov - "2025-11-01T15:00:00"
Med: Fixed