### PR TITLE
cover contexts where the grouping is used in a schedule request

### DIFF
--- a/yang/ietf-schedule.yang
+++ b/yang/ietf-schedule.yang
@@ -708,9 +708,8 @@ module ietf-schedule {
       type identityref {
         base schedule-type;
       }
-      config false;
       description
-        "Reports the schedule type.";
+        "Indicates the schedule type.";
     }
     leaf last-update {
       type yang:date-and-time;


### PR DESCRIPTION
The type/state can be tweaked in a request.