### PR TITLE
report local time

### DIFF
--- a/yang/ietf-schedule.yang
+++ b/yang/ietf-schedule.yang
@@ -744,6 +744,13 @@ module ietf-schedule {
       description
         "Indicates the schedule type.";
     }
+    leaf local-time {
+      type yang:date-and-time;
+      config false;
+      description
+        "Reports the local time as used by the entity that
+         hosts the schedule.";
+    }
     leaf last-update {
       type yang:date-and-time;
       config false;


### PR DESCRIPTION
   schedLocalTime OBJECT-TYPE
       SYNTAX      DateAndTime (SIZE (11))
       MAX-ACCESS  read-only
       STATUS      current
       DESCRIPTION
           "The local time used by the scheduler.  Schedules which
            refer to calendar time will use the local time indicated
            by this object.  An implementation MUST return all 11 bytes
            of the DateAndTime textual-convention so that a manager
            may retrieve the offset from GMT time."
       ::= { schedObjects 1 }