### PR TITLE
fix a naming conflict

### DIFF
--- a/draft-ietf-netmod-schedule-yang.md
+++ b/draft-ietf-netmod-schedule-yang.md
@@ -212,14 +212,13 @@ System:
    start ("period-start") and a positive time duration ("duration"). For the first
    format, the start of the period MUST be before the end of the period.
 
-   The "description" includes a description of the period. No constraint is imposed
+   The "period-description" includes a description of the period. No constraint is imposed
    on the structure nor the use of this parameter.
 
 ~~~~
 {::include ./yang/tree/period-grp.txt}
 ~~~~
 {: #pt-tree title="Period of Time Grouping Tree Structure"}
-
 
 ### The "recurrence" Grouping {#sec-rec}
 
@@ -239,7 +238,7 @@ System:
   every minute for a minutely rule, every hour for an hourly rule, every day for a
   daily rule, and so on. Note that per {{Section 4.13 of ?I-D.ietf-netmod-rfc8407bis}}, no "default" substatement is used here because there are cases (e.g., profiling) where the use of the default is problematic.
 
-  The "description" includes a description of the period. No constraint is imposed
+  The "recurrence-description" includes a description of the period. No constraint is imposed
   on the structure nor the use of this parameter.
 
 ### The "recurrence-utc" Grouping {#sec-rec-utc}

--- a/yang/ietf-schedule.yang
+++ b/yang/ietf-schedule.yang
@@ -344,7 +344,7 @@ module ietf-schedule {
     reference
       "RFC 5545: Internet Calendaring and Scheduling Core Object
                  Specification (iCalendar), Section 3.3.9";
-    leaf description {
+    leaf period-description {
       type string;
       description
         "Provides a description of the period.";
@@ -404,7 +404,7 @@ module ietf-schedule {
   grouping recurrence {
     description
       "A simple definition of recurrence.";
-    leaf description {
+    leaf recurrence-description {
       type string;
       description
         "Provides a description of the recurrence.";

--- a/yang/tree/period-grp.txt
+++ b/yang/tree/period-grp.txt
@@ -3,7 +3,7 @@ module: ietf-schedule
   grouping generic-schedule-params:
     ...
   grouping period-of-time:
-    +-- description?            string
+    +-- period-description?     string
     +-- period-start            yang:date-and-time
     +-- time-zone-identifier?   sys:timezone-name
     +-- (period-type)?

--- a/yang/tree/rec-grp.txt
+++ b/yang/tree/rec-grp.txt
@@ -5,7 +5,7 @@ module: ietf-schedule
   grouping period-of-time:
     ...
   grouping recurrence:
-    +-- description?   string
+    +-- recurrence-description?   string
     +-- frequency      identityref
     +-- interval?      uint32
   grouping recurrence-utc:

--- a/yang/tree/rec-tz-dt-grp.txt
+++ b/yang/tree/rec-tz-dt-grp.txt
@@ -22,7 +22,7 @@ module: ietf-schedule
     |  |  +-- until?        yang:date-and-time
     |  +--:(count)
     |     +-- count?        uint32
-    +-- description?        string
+    +-- recurrence-description?        string
     +-- frequency           identityref
     +-- interval?           uint32
     +-- period* [period-start]

--- a/yang/tree/rec-tz-grp.txt
+++ b/yang/tree/rec-tz-grp.txt
@@ -18,7 +18,7 @@ module: ietf-schedule
     |  |  +-- until?        yang:date-and-time
     |  +--:(count)
     |     +-- count?        uint32
-    +-- description?        string
+    +-- recurrence-description?        string
     +-- frequency           identityref
     +-- interval?           uint32
   grouping recurrence-utc-with-date-times:

--- a/yang/tree/rec-utc-dt-grp.txt
+++ b/yang/tree/rec-utc-dt-grp.txt
@@ -19,7 +19,7 @@ module: ietf-schedule
     |  |  +-- utc-until?    yang:date-and-time
     |  +--:(count)
     |     +-- count?        uint32
-    +-- description?        string
+    +-- recurrence-description?        string
     +-- frequency           identityref
     +-- interval?           uint32
     +-- period-timeticks* [period-start]

--- a/yang/tree/rec-utc-grp.txt
+++ b/yang/tree/rec-utc-grp.txt
@@ -15,7 +15,7 @@ module: ietf-schedule
     |  |  +-- utc-until?    yang:date-and-time
     |  +--:(count)
     |     +-- count?        uint32
-    +-- description?        string
+    +-- recurrence-description?        string
     +-- frequency           identityref
     +-- interval?           uint32
   grouping recurrence-with-time-zone:


### PR DESCRIPTION
for models where both period and recursion are used (e.g., within a same choice)