### PR TITLE
add schedTriggers and remove schedValue

### DIFF
--- a/draft-ietf-netmod-schedule-yang.md
+++ b/draft-ietf-netmod-schedule-yang.md
@@ -469,7 +469,7 @@ can be mapped to YANG parameters.
 |schedLastFailure| Not Supported   |
 |schedLastFailed|   last-failed-occurrence|
 |schedStorageType|  Not Supported    |
-|schedValue|  Not Supported    |
+|schedTriggers|  counter    |
 {: #mapping title="YANG/MIB Mapping"}
 
 #  The "ietf-schedule" YANG Module {#sec-schedule}

--- a/draft-ietf-netmod-schedule-yang.md
+++ b/draft-ietf-netmod-schedule-yang.md
@@ -471,7 +471,7 @@ can be mapped to YANG parameters.
 |schedStorageType|  Not Supported    |
 |schedVariable| not applicable |
 |schedValue| not applicable |
-|schedTriggers|  failure-counter + counter   |
+|schedTriggers|  counter/failure-counter   |
 {: #mapping title="YANG/MIB Mapping"}
 
 #  The "ietf-schedule" YANG Module {#sec-schedule}

--- a/draft-ietf-netmod-schedule-yang.md
+++ b/draft-ietf-netmod-schedule-yang.md
@@ -469,7 +469,9 @@ can be mapped to YANG parameters.
 |schedLastFailure| Not Supported   |
 |schedLastFailed|   last-failed-occurrence|
 |schedStorageType|  Not Supported    |
-|schedTriggers|  counter    |
+|schedVariable| not applicable |
+|schedValue| not applicable |
+|schedTriggers|  failure-counter + counter   |
 {: #mapping title="YANG/MIB Mapping"}
 
 #  The "ietf-schedule" YANG Module {#sec-schedule}

--- a/yang/ietf-schedule.yang
+++ b/yang/ietf-schedule.yang
@@ -756,8 +756,9 @@ module ietf-schedule {
       type yang:counter32;
       config false;
       description
-        "The counter of occurrences since the schedule was enabled.
-         The count wraps around when it reaches the maximum value.";
+        "The number of occurrences while invoking the scheduled action
+         successfully. The count wraps around when it reaches the 
+         maximum value.";
     }
     leaf last-occurrence {
       when "derived-from-or-self(../schedule-type, "

--- a/yang/ietf-schedule.yang
+++ b/yang/ietf-schedule.yang
@@ -756,9 +756,9 @@ module ietf-schedule {
       type yang:counter32;
       config false;
       description
-        "The number of occurrences while invoking the scheduled action
-         successfully. The count wraps around when it reaches the 
-         maximum value.";
+        "The number of occurrences while invoking the scheduled 
+         action successfully. The count wraps around when it reaches
+         the maximum value.";
     }
     leaf last-occurrence {
       when "derived-from-or-self(../schedule-type, "


### PR DESCRIPTION
schedValue is "The value which is written to the MIB object pointed to by
            schedVariable when the scheduler invokes an action."
schedVariable is "An object identifier pointing to a local MIB variable
            which resolves to an ASN.1 primitive type of INTEGER."
both seem parameters specific to SNMP, and thus may be omitted from the mapping?

Meanwhile, schedTriggers : "This variable counts the number of attempts (either
            successful or failed) to invoke the scheduled action." this seems to be related to leaf "counter" inside schedule-status grouping...